### PR TITLE
Handle Optional return value in repo

### DIFF
--- a/modFastVM/modFastVM.iml
+++ b/modFastVM/modFastVM.iml
@@ -20,6 +20,5 @@
     <orderEntry type="library" name="junit" level="project" scope="TEST" />
     <orderEntry type="library" name="truth" level="project" scope="TEST" />
     <orderEntry type="module" module-name="modAionImpl" scope="TEST" />
-    <orderEntry type="module" module-name="modPrecompiled" />
   </component>
 </module>

--- a/modFastVM/modFastVM.iml
+++ b/modFastVM/modFastVM.iml
@@ -17,8 +17,8 @@
     <orderEntry type="library" name="libJson" level="project" />
     <orderEntry type="library" name="slf4j-api" level="project" />
     <orderEntry type="library" name="libnsc" level="project" />
-    <orderEntry type="library" scope="TEST" name="junit" level="project" />
-    <orderEntry type="library" scope="TEST" name="truth" level="project" />
+    <orderEntry type="library" scope="junit" level="project" scope="TEST" />
+    <orderEntry type="library" scope="truth" level="project" scope="TEST" />
     <orderEntry type="module" module-name="modAionImpl" scope="TEST" />
     <orderEntry type="module" module-name="modPrecompiled" />
   </component>

--- a/modFastVM/modFastVM.iml
+++ b/modFastVM/modFastVM.iml
@@ -17,8 +17,8 @@
     <orderEntry type="library" name="libJson" level="project" />
     <orderEntry type="library" name="slf4j-api" level="project" />
     <orderEntry type="library" name="libnsc" level="project" />
-    <orderEntry type="library" scope="junit" level="project" scope="TEST" />
-    <orderEntry type="library" scope="truth" level="project" scope="TEST" />
+    <orderEntry type="library" name="junit" level="project" scope="TEST" />
+    <orderEntry type="library" name="truth" level="project" scope="TEST" />
     <orderEntry type="module" module-name="modAionImpl" scope="TEST" />
     <orderEntry type="module" module-name="modPrecompiled" />
   </component>

--- a/modFastVM/modFastVM.iml
+++ b/modFastVM/modFastVM.iml
@@ -17,8 +17,9 @@
     <orderEntry type="library" name="libJson" level="project" />
     <orderEntry type="library" name="slf4j-api" level="project" />
     <orderEntry type="library" name="libnsc" level="project" />
-    <orderEntry type="library" name="junit" level="project" scope="TEST" />
-    <orderEntry type="library" name="truth" level="project" scope="TEST" />
+    <orderEntry type="library" scope="TEST" name="junit" level="project" />
+    <orderEntry type="library" scope="TEST" name="truth" level="project" />
     <orderEntry type="module" module-name="modAionImpl" scope="TEST" />
+    <orderEntry type="module" module-name="modPrecompiled" />
   </component>
 </module>

--- a/modFastVM/src/org/aion/fastvm/Callback.java
+++ b/modFastVM/src/org/aion/fastvm/Callback.java
@@ -20,6 +20,7 @@
  ******************************************************************************/
 package org.aion.fastvm;
 
+import java.util.Optional;
 import org.aion.base.db.IRepositoryCache;
 import org.aion.base.type.Address;
 import org.aion.base.util.ByteUtil;
@@ -144,11 +145,11 @@ public class Callback {
      * @return
      */
     public static byte[] getStorage(byte[] address, byte[] key) {
-        DataWord value = repo().getStorageValue(Address.wrap(address), new DataWord(key));
+        Optional<DataWord> value = repo().getStorageValue(Address.wrap(address), new DataWord(key));
 
         // System.err.println("GET_STORAGE: address = " + Hex.toHexString(address) + ", key = " + Hex.toHexString(key) + ", value = " + (value == null ? "":Hex.toHexString(value.getData())));
 
-        return value == null ? DataWord.ZERO.getData() : value.getData();
+        return !value.isPresent() ? DataWord.ZERO.getData() : value.get().getData();
     }
 
     /**

--- a/modFastVM/src/org/aion/vm/precompiled/TotalCurrencyContract.java
+++ b/modFastVM/src/org/aion/vm/precompiled/TotalCurrencyContract.java
@@ -20,6 +20,7 @@
  ******************************************************************************/
 package org.aion.vm.precompiled;
 
+import java.util.Optional;
 import org.aion.base.db.IRepositoryCache;
 import org.aion.base.type.Address;
 import org.aion.base.util.BIUtil;
@@ -107,8 +108,8 @@ public class TotalCurrencyContract extends PrecompiledContracts.StatefulPrecompi
             return new ExecutionResult(ExecutionResult.Code.OUT_OF_NRG, 0);
         }
 
-        DataWord balanceData = this.track.getStorageValue(this.address, new DataWord(input));
-        return new ExecutionResult(ExecutionResult.Code.SUCCESS, nrg - COST, balanceData.getData());
+        Optional<DataWord> balanceData = this.track.getStorageValue(this.address, new DataWord(input));
+        return new ExecutionResult(ExecutionResult.Code.SUCCESS, nrg - COST, balanceData.get().getData());
     }
 
     private ExecutionResult executeUpdateTotalBalance(byte[] input, long nrg) {
@@ -156,8 +157,8 @@ public class TotalCurrencyContract extends PrecompiledContracts.StatefulPrecompi
         }
 
         // payload processing
-        DataWord totalCurr = this.track.getStorageValue(this.address, chainId);
-        BigInteger totalCurrBI = totalCurr == null ? BigInteger.ZERO : BIUtil.toBI(totalCurr.getData());
+        Optional<DataWord> totalCurr = this.track.getStorageValue(this.address, chainId);
+        BigInteger totalCurrBI = !totalCurr.isPresent() ? BigInteger.ZERO : BIUtil.toBI(totalCurr.get().getData());
         BigInteger value = BIUtil.toBI(amount);
 
         if (signum != 0x0 && signum != 0x1) {

--- a/modFastVM/test/org/aion/fastvm/DummyRepository.java
+++ b/modFastVM/test/org/aion/fastvm/DummyRepository.java
@@ -142,12 +142,12 @@ public class DummyRepository implements IRepositoryCache<AccountState, DataWord,
     }
 
     @Override
-    public DataWord getStorageValue(Address addr, DataWord key) {
+    public Optional<DataWord> getStorageValue(Address addr, DataWord key) {
         Map<String, byte[]> map = storage.get(addr);
         if (map != null && map.containsKey(key.toString())) {
-            return new DataWord(map.get(key.toString()));
+            return Optional.of(new DataWord(map.get(key.toString())));
         } else {
-            return DataWord.ZERO;
+            return Optional.empty();
         }
     }
 


### PR DESCRIPTION
Some small changes to allow the fastVM to handle the Optional return value when the getStorageValue method is used. <a href="https://github.com/aionnetwork/aion/pull/540">This PR</a> in the aion project proposed to make the change to Optional.