### PR TITLE
Separate test precompiled contract

### DIFF
--- a/modFastVM/src/org/aion/fastvm/Callback.java
+++ b/modFastVM/src/org/aion/fastvm/Callback.java
@@ -45,6 +45,7 @@ import org.aion.precompiled.ContractFactory;
 import org.aion.vm.AbstractExecutionResult.ResultCode;
 import org.aion.vm.ExecutionContext;
 import org.aion.vm.ExecutionResult;
+import org.aion.vm.IContractFactory;
 import org.aion.vm.IPrecompiledContract;
 import org.aion.zero.types.AionInternalTx;
 import org.apache.commons.lang3.ArrayUtils;
@@ -260,7 +261,7 @@ public class Callback {
      * @param ctx
      * @return
      */
-    private static IExecutionResult doCall(ExecutionContext ctx, FastVM jit, ContractFactory factory) {
+    private static IExecutionResult doCall(ExecutionContext ctx, FastVM jit, IContractFactory factory) {
         Address codeAddress = ctx.address();
         if (ctx.kind() == ExecutionContext.CALLCODE || ctx.kind() == ExecutionContext.DELEGATECALL) {
             ctx.address = context().address();
@@ -280,7 +281,7 @@ public class Callback {
             track.addBalance(ctx.address(), ctx.callValue().value());
         }
 
-        IPrecompiledContract pc = factory.fetchPrecompiledContract(ctx, track);
+        IPrecompiledContract pc = factory.getPrecompiledContract(ctx, track);
         if (pc != null) {
             result = pc.execute(ctx.callData(), ctx.nrgLimit());
         } else {

--- a/modFastVM/test/org/aion/ContractFactoryMock.java
+++ b/modFastVM/test/org/aion/ContractFactoryMock.java
@@ -1,0 +1,51 @@
+package org.aion;
+
+import org.aion.base.db.IRepositoryCache;
+import org.aion.base.type.IExecutionResult;
+import org.aion.base.vm.IDataWord;
+import org.aion.mcf.core.AccountState;
+import org.aion.mcf.db.IBlockStoreBase;
+import org.aion.vm.AbstractExecutionResult.ResultCode;
+import org.aion.vm.ExecutionContext;
+import org.aion.vm.ExecutionResult;
+import org.aion.vm.IContractFactory;
+import org.aion.vm.IPrecompiledContract;
+
+public class ContractFactoryMock implements IContractFactory {
+    public static final String CALL_ME = "9999999999999999999999999999999999999999999999999999999999999999";
+
+
+    /**
+     * A mocked up version of getPrecompiledContract that only returns TestPrecompiledContract.
+     */
+    @Override
+    public IPrecompiledContract getPrecompiledContract(
+                ExecutionContext context,
+                IRepositoryCache<AccountState, IDataWord, IBlockStoreBase<?, ?>> track) {
+
+        switch (context.address().toString()) {
+            case CALL_ME: return new CallMePrecompiledContract();
+            default: return null;
+        }
+    }
+
+    public static class CallMePrecompiledContract implements IPrecompiledContract {
+        public static final String head = "echo: ";
+        public static boolean youCalledMe = false;
+
+        /**
+         * Returns a byte array that begins with the byte version of the characters in the public
+         * variable 'head' followed by the bytes in input.
+         */
+        @Override
+        public IExecutionResult execute(byte[] input, long nrgLimit) {
+            youCalledMe = true;
+            byte[] msg = new byte[head.getBytes().length + input.length];
+            System.arraycopy(head.getBytes(), 0, msg, 0, head.getBytes().length);
+            System.arraycopy(input, 0, msg, head.getBytes().length, input.length);
+            return new ExecutionResult(ResultCode.SUCCESS, nrgLimit, msg);
+        }
+
+    }
+
+}

--- a/modFastVM/test/org/aion/fastvm/CallbackUnitTest.java
+++ b/modFastVM/test/org/aion/fastvm/CallbackUnitTest.java
@@ -1734,12 +1734,12 @@ public class CallbackUnitTest {
         when(contract.execute(Mockito.any(byte[].class), Mockito.anyLong())).thenReturn(result);
         ContractFactory factory = mock(ContractFactory.class);
         if (result == null) {
-            when(factory.fetchPrecompiledContract(Mockito.any(ExecutionContext.class),
+            when(factory.getPrecompiledContract(Mockito.any(ExecutionContext.class),
                 Mockito.any(IRepositoryCache.class))).
                 thenReturn(null);
             return factory;
         } else {
-            when(factory.fetchPrecompiledContract(Mockito.any(ExecutionContext.class),
+            when(factory.getPrecompiledContract(Mockito.any(ExecutionContext.class),
                 Mockito.any(IRepositoryCache.class))).
                 thenReturn(contract);
 

--- a/modFastVM/test/org/aion/fastvm/TestVMProvider.java
+++ b/modFastVM/test/org/aion/fastvm/TestVMProvider.java
@@ -4,15 +4,16 @@ import org.aion.base.db.IRepositoryCache;
 import org.aion.precompiled.ContractFactory;
 import org.aion.vm.ExecutionContext;
 import org.aion.vm.ExecutorProvider;
+import org.aion.vm.IContractFactory;
 import org.aion.vm.IPrecompiledContract;
 import org.aion.vm.VirtualMachine;
 
 public class TestVMProvider implements ExecutorProvider {
-    private ContractFactory factory = new ContractFactory();
+    private IContractFactory factory = new ContractFactory();
 
     @Override
     public IPrecompiledContract getPrecompiledContract(ExecutionContext context, IRepositoryCache track) {
-        return factory.fetchPrecompiledContract(context, track);
+        return factory.getPrecompiledContract(context, track);
     }
 
     @Override
@@ -20,7 +21,7 @@ public class TestVMProvider implements ExecutorProvider {
         return new FastVM();
     }
 
-    public void setFactory(ContractFactory factory) {
+    public void setFactory(IContractFactory factory) {
         this.factory = factory;
     }
 }


### PR DESCRIPTION
Removes the precompiled contract for testing from `modPrecompiled` and places a new mocked contract factory in the fastVM that was using that test PC.

See aion side of PR <a href="https://github.com/aionnetwork/aion/pull/600">here</a>.