### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,8 +34,6 @@
 # Build files
 build/
 
-# IntelliJ config files
-*.iml
-
 # Gradle 
 modFastVM/.gradle/**
+modFastVM/out/


### PR DESCRIPTION
- the IDE does not allow non-Gradle Java modules (.iml files) and Android-Gradle modules in one project: ensuring that these files are not hidden by gitignore; 
- adding the execution folder to gitignore.