### PR TITLE
Use libjson from maven repo instead of locally built jar

### DIFF
--- a/modFastVM/build.gradle
+++ b/modFastVM/build.gradle
@@ -27,8 +27,7 @@ dependencies {
     compile project(':modMcf')
     compile project(':modVM')
     compile project(':modPrecompiled')
-    compile files("${rootProject.projectDir}/lib/libJson.jar")
-    compile files("${rootProject.projectDir}/lib/libnsc.jar")
+    compile 'org.json:json:20180813'
     compile group: 'org.apache.commons', name: 'commons-collections4', version: '4.0'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
     compile 'org.slf4j:slf4j-api:1.7.25'


### PR DESCRIPTION
- Instead of using libJson built by aion repo's gradle build scripts, just pull it from a Maven repo.
- Tested that kernel can still compile and start up after this change
- For test results, see CI tests for the corresponding PR in aion repo; it points to this branch for aion_fastvm: https://github.com/aionnetwork/aion/pull/759