### PR TITLE
Update to `vm_api` dependency

### DIFF
--- a/modFastVM/build.gradle
+++ b/modFastVM/build.gradle
@@ -30,7 +30,7 @@ sourceSets {
 
 dependencies {
 
-    compile 'network.aion:vm-api4j:0.4.0'
+    compile project(':aion_vm_api')
     compile 'network.aion:util4j:0.4.0'
     compile 'network.aion:crypto4j:0.4.0'
 

--- a/modFastVM/test/org/aion/vm/DummyRepository.java
+++ b/modFastVM/test/org/aion/vm/DummyRepository.java
@@ -247,6 +247,11 @@ public class DummyRepository implements RepositoryCache<AccountState, IBlockStor
     public void removeTxBatch(Set<byte[]> pendingTx, boolean isPool) {}
 
     @Override
+    public byte getVMUsed(Address contract) {
+        return 0x01;
+    }
+
+    @Override
     public void compact() {
         throw new UnsupportedOperationException(
                 "The tracking cache cannot be compacted. \'Compact\' should be called on the tracked repository.");


### PR DESCRIPTION
The `vm_api` got updated to remove the specific AVM contract prefix and query the repository for the VM used at contract deployment.

These changes correspond to https://github.com/aionnetwork/aion/pull/851